### PR TITLE
Fix dashboard data loading regression and align hero CTA styling

### DIFF
--- a/ansibledb2-dashboard.html
+++ b/ansibledb2-dashboard.html
@@ -458,18 +458,33 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>
     <script>
-        // Load JSON data from your provided files
-        fetch('ansibledb2_sample_hosts.json')
-            .then(r => r.json())
-            .then(hosts => {
-                fetch('ansibledb2_sample_network_devices.json')
-                    .then(r => r.json())
-                    .then(devices => {
-                        initDashboard(hosts, devices);
-                    });
+        window.dashboardInitialized = false;
+
+        function fetchJson(url) {
+            return fetch(url).then(response => {
+                if (!response.ok) {
+                    throw new Error(`Failed to load ${url}: ${response.status} ${response.statusText}`);
+                }
+                return response.json();
+            });
+        }
+
+        Promise.all([
+            fetchJson('ansibledb2_sample_hosts.json'),
+            fetchJson('ansibledb2_sample_network_devices.json')
+        ])
+            .then(([hosts, devices]) => {
+                initDashboard(hosts, devices);
+            })
+            .catch(error => {
+                console.error('Unable to load dashboard data, rendering empty state.', error);
+                initDashboard([], []);
             });
 
         function initDashboard(hosts, devices) {
+            window.dashboardInitialized = true;
+            updateLastUpdated(hosts);
+
             // Render all tabs
             renderOverviewTab(hosts, devices);
             renderSecurityTab(hosts);
@@ -497,6 +512,11 @@
             ).length;
 
             // Render stats
+            const formatPercentage = (part, total) => {
+                if (!total) return '0.0';
+                return ((part / total) * 100).toFixed(1);
+            };
+
             document.getElementById('overviewStats').innerHTML = `
                 <div class="stat-card">
                     <div class="stat-label">Total Hosts</div>
@@ -509,12 +529,12 @@
                 <div class="stat-card">
                     <div class="stat-label">Critical Patch Issues</div>
                     <div class="stat-value danger">${criticalPatches}</div>
-                    <div class="stat-subtext">${((criticalPatches/totalHosts)*100).toFixed(1)}% of fleet</div>
+                    <div class="stat-subtext">${formatPercentage(criticalPatches, totalHosts)}% of fleet</div>
                 </div>
                 <div class="stat-card">
                     <div class="stat-label">CIS Non-Compliant</div>
                     <div class="stat-value warning">${cisNonCompliant}</div>
-                    <div class="stat-subtext">${((cisNonCompliant/totalHosts)*100).toFixed(1)}% of fleet</div>
+                    <div class="stat-subtext">${formatPercentage(cisNonCompliant, totalHosts)}% of fleet</div>
                 </div>
             `;
 
@@ -1005,16 +1025,24 @@
             return `${Math.floor(diff / 1440)} days ago`;
         }
 
-        // If JSON files aren't available, use inline data
-        setTimeout(() => {
-            if (!window.dashboardInitialized) {
-                console.log('Loading inline data...');
-                // Initialize with empty data to show the structure
-                initDashboard([], []);
+        function updateLastUpdated(hosts) {
+            const lastUpdateElement = document.getElementById('lastUpdate');
+            if (!hosts.length) {
+                lastUpdateElement.textContent = 'Awaiting data';
+                return;
             }
-        }, 1000);
-        
-        window.dashboardInitialized = false;
+
+            const latestTimestamp = hosts.reduce((latest, host) => {
+                const timestamp = new Date(host.collection_timestamp);
+                return (!latest || timestamp > latest) ? timestamp : latest;
+            }, null);
+
+            if (latestTimestamp) {
+                lastUpdateElement.textContent = formatTimestamp(latestTimestamp);
+            } else {
+                lastUpdateElement.textContent = 'Just now';
+            }
+        }
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -216,15 +216,17 @@
             color: var(--primary);
         }
         .dashboard-btn {
-            background: linear-gradient(135deg, var(--accent), #38a169);
+            background: rgba(255, 255, 255, 0.12);
             color: white;
-            border: none;
-            box-shadow: 0 8px 25px rgba(72, 187, 120, 0.3);
+            border: 2px solid rgba(255, 255, 255, 0.6);
+            box-shadow: 0 12px 30px rgba(102, 126, 234, 0.25);
+            backdrop-filter: blur(6px);
         }
-        
+
         .dashboard-btn:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 15px 40px rgba(72, 187, 120, 0.4);
+            background: white;
+            color: var(--primary);
+            box-shadow: 0 18px 45px rgba(102, 126, 234, 0.35);
         }
 
         @keyframes fadeInUp {


### PR DESCRIPTION
## Summary
- replace the dashboard's chained fetch calls with a single Promise.all wrapper that adds proper error handling and avoids resetting to empty data
- surface the latest collection timestamp in the header and guard percentage calculations against divide-by-zero fallbacks
- restyle the hero "View Dashboard" button so its appearance matches the other call-to-action buttons

## Testing
- Manual verification: loaded index.html and ansibledb2-dashboard.html in a local browser session

------
https://chatgpt.com/codex/tasks/task_b_68e426706a1c8325b08ac7680aee127e