### PR TITLE
Fix hero fade effect on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1483,10 +1483,26 @@ curl http://localhost:8080/health</code></pre>
         window.addEventListener('scroll', () => {
             const scrolled = window.pageYOffset;
             const hero = document.querySelector('.hero-content');
-            if (hero) {
+            if (!hero) return;
+
+            if (window.innerWidth > 768) {
                 hero.style.transform = `translateY(${scrolled * 0.5}px)`;
                 const fadeAmount = Math.max(1 - (scrolled * 0.0012), 0.25);
                 hero.style.opacity = fadeAmount;
+            } else {
+                hero.style.transform = 'translateY(0)';
+                hero.style.opacity = 1;
+            }
+        });
+
+        // Ensure hero content resets when resizing to smaller screens
+        window.addEventListener('resize', () => {
+            const hero = document.querySelector('.hero-content');
+            if (!hero) return;
+
+            if (window.innerWidth <= 768) {
+                hero.style.transform = 'translateY(0)';
+                hero.style.opacity = 1;
             }
         });
 


### PR DESCRIPTION
## Summary
- prevent the hero parallax fade from hiding call-to-action buttons on small screens
- reset hero styles when resizing to mobile widths to keep the buttons visible

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68e4ae03be388325a88b5ec2646efc6c