### PR TITLE
Improve mobile layout and add ownership messaging

### DIFF
--- a/ansibledb2-dashboard.html
+++ b/ansibledb2-dashboard.html
@@ -299,9 +299,16 @@
 
         .pie-chart {
             position: relative;
-            width: 200px;
-            height: 200px;
-            flex: 0 0 200px;
+            width: min(200px, 100%);
+            aspect-ratio: 1 / 1;
+            flex: 1 1 180px;
+            max-width: 240px;
+        }
+
+        .pie-chart svg {
+            width: 100%;
+            height: 100%;
+            display: block;
         }
 
         .legend {
@@ -504,6 +511,32 @@
             font-weight: 600;
         }
 
+        .site-footer {
+            margin-top: 3rem;
+            padding: 2.5rem 1.5rem;
+            text-align: center;
+            background: linear-gradient(135deg, #1f2330, #0f1116);
+            border-top: 1px solid #2d3139;
+            color: #e2e3e6;
+            letter-spacing: 0.3px;
+        }
+
+        .site-footer p {
+            margin: 0.35rem 0;
+            font-size: 0.95rem;
+        }
+
+        .site-footer strong {
+            color: #fff;
+        }
+
+        .site-footer span {
+            display: block;
+            margin-top: 0.35rem;
+            font-size: 0.85rem;
+            color: #8e9196;
+        }
+
         .os-overview {
             display: grid;
             grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
@@ -618,6 +651,19 @@
             }
             .pie-chart-container {
                 align-items: center;
+                justify-content: center;
+            }
+            .pie-chart {
+                max-width: 200px;
+            }
+            .legend {
+                width: 100%;
+            }
+            .site-footer {
+                padding: 2rem 1rem;
+            }
+            .site-footer p {
+                font-size: 0.9rem;
             }
         }
     </style>
@@ -768,6 +814,11 @@
             </div>
         </div>
     </div>
+
+    <footer class="site-footer">
+        <p>Brought to you by <strong>London Infrastructure as Code Ltd.</strong></p>
+        <span>&copy; 2025 AnsibleDB2. All rights reserved.</span>
+    </footer>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>
@@ -1979,9 +2030,10 @@
         function renderPieChart(chartId, legendId, data) {
             const total = data.reduce((sum, d) => sum + d.count, 0);
             const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-            svg.setAttribute('width', '200');
-            svg.setAttribute('height', '200');
+            svg.setAttribute('width', '100%');
+            svg.setAttribute('height', '100%');
             svg.setAttribute('viewBox', '0 0 200 200');
+            svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
             
             let currentAngle = 0;
             const centerX = 100;
@@ -2013,10 +2065,18 @@
                 currentAngle += angle;
             });
             
-            document.getElementById(chartId).appendChild(svg);
-            
+            const chartElement = document.getElementById(chartId);
+            if (!chartElement) {
+                return;
+            }
+            chartElement.innerHTML = '';
+            chartElement.appendChild(svg);
+
             // Legend
             const legend = document.getElementById(legendId);
+            if (!legend) {
+                return;
+            }
             legend.innerHTML = data.map(item => `
                 <div class="legend-item">
                     <div class="legend-color" style="background: ${item.color}"></div>

--- a/docs.html
+++ b/docs.html
@@ -176,6 +176,16 @@
             color: #cbd5f5;
         }
 
+        footer .footer-attribution {
+            margin-top: 0.75rem;
+            font-size: 0.9rem;
+            color: #cbd5f5;
+        }
+
+        footer .footer-attribution strong {
+            color: #fff;
+        }
+
         @media (max-width: 720px) {
             .nav-links {
                 display: none;
@@ -289,6 +299,7 @@
     <footer>
         <p>© 2025 AnsibleDB2. Looking for repositories? Visit our <a href="repos.html">release portal</a> or check the
             <a href="github.html">GitHub preview</a>.</p>
+        <p class="footer-attribution">Brought to you by <strong>London Infrastructure as Code Ltd.</strong></p>
     </footer>
 </body>
 </html>

--- a/github.html
+++ b/github.html
@@ -103,6 +103,20 @@
             color: #4a5568;
         }
 
+        footer p {
+            margin: 0.35rem 0;
+        }
+
+        footer .footer-attribution {
+            font-size: 0.9rem;
+            color: #2d3748;
+            font-weight: 600;
+        }
+
+        footer .footer-attribution strong {
+            color: var(--primary);
+        }
+
         @media (max-width: 640px) {
             .nav-links {
                 display: none;
@@ -138,7 +152,8 @@
     </main>
 
     <footer>
-        © 2025 AnsibleDB2. Follow product milestones from the <a href="docs.html">Docs hub</a>.
+        <p>© 2025 AnsibleDB2. Follow product milestones from the <a href="docs.html">Docs hub</a>.</p>
+        <p class="footer-attribution">Brought to you by <strong>London Infrastructure as Code Ltd.</strong></p>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -644,6 +644,16 @@
             color: #cbd5e0;
         }
 
+        .footer-attribution {
+            margin-top: 1.5rem;
+            font-size: 0.95rem;
+            color: #e2e8f0;
+        }
+
+        .footer-attribution strong {
+            color: #fff;
+        }
+
         /* Scroll indicator */
         .scroll-indicator {
             position: absolute;
@@ -667,6 +677,10 @@
 
         /* Mobile responsive */
         @media (max-width: 768px) {
+            .hero {
+                padding-top: 140px;
+                padding-top: calc(140px + env(safe-area-inset-top));
+            }
             .hero h1 {
                 font-size: 2.5rem;
             }
@@ -1384,6 +1398,7 @@ curl http://localhost:8080/health</code></pre>
         </div>
         <div class="footer-bottom">
             <p>&copy; 2025 AnsibleDB2. All rights reserved. | <a href="#privacy" style="color: #cbd5e0;">Privacy Policy</a> | <a href="#terms" style="color: #cbd5e0;">Terms of Service</a></p>
+            <p class="footer-attribution">Brought to you by <strong>London Infrastructure as Code Ltd.</strong></p>
         </div>
     </footer>
 

--- a/repos.html
+++ b/repos.html
@@ -124,6 +124,21 @@
             color: #4a5568;
         }
 
+        footer p {
+            margin: 0.35rem 0;
+        }
+
+        footer .footer-attribution {
+            margin-top: 0.5rem;
+            font-size: 0.9rem;
+            color: #2d3748;
+            font-weight: 600;
+        }
+
+        footer .footer-attribution strong {
+            color: var(--primary);
+        }
+
         @media (max-width: 640px) {
             .nav-links {
                 display: none;
@@ -173,8 +188,9 @@
     </main>
 
     <footer>
-        © 2025 AnsibleDB2. Explore our <a href="docs.html">documentation hub</a> for deployment guidance while we finish
-        the repository experience.
+        <p>© 2025 AnsibleDB2. Explore our <a href="docs.html">documentation hub</a> for deployment guidance while we finish
+            the repository experience.</p>
+        <p class="footer-attribution">Brought to you by <strong>London Infrastructure as Code Ltd.</strong></p>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- increase the hero padding on small screens so the navigation no longer overlaps the headline
- make the infrastructure distribution pie chart responsive and guard its rendering logic
- add the London Infrastructure as Code Ltd. ownership message to the site footers across pages

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_b_68e4c9a70a2883258142fa576df04ec3